### PR TITLE
Fix x-axis for plot of historical prices

### DIFF
--- a/Monte_Carlo_Previsao_Precos.ipynb
+++ b/Monte_Carlo_Previsao_Precos.ipynb
@@ -250,7 +250,7 @@
     "# Criando figura para visualizar simulações\n",
     "plt.figure(figsize=(10, 6))\n",
     "plt.plot(predicts.index,predicts, lw=1.5)\n",
-    "plt.plot(df_prices[TICKER].tail(10).index,df_prices[TICKER].tail(10),color='black',label=TICKER)\n",
+    "plt.plot(df_prices['Date'].tail(10),df_prices[TICKER].tail(10),color='black',label=TICKER)\n",
     "# Personalizando\n",
     "plt.title('Simulação de Monte Carlo para Preços com Processo de Wiener',size=16)\n",
     "plt.ylabel('Preço ($)')\n",


### PR DESCRIPTION
## Summary
- fix x-axis in `Monte_Carlo_Previsao_Precos.ipynb` when plotting recent historical prices over simulations

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_686ad4725858832a816f4e85ad7eb4d4